### PR TITLE
feat(prefs): replace force dark toggle with mode selector

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -20,3 +20,17 @@ jobs:
 
       - name: Build
         run: ./gradlew assembleDebug assembleRelease
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: amznkiller-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: amznkiller-release-apk
+          path: app/build/outputs/apk/release/*.apk
+          if-no-files-found: warn

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/ForceDarkMode.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/ForceDarkMode.kt
@@ -1,0 +1,36 @@
+package eu.hxreborn.amznkiller.prefs
+
+enum class ForceDarkMode {
+    OFF,
+    FOLLOW_SYSTEM,
+    ON,
+    ;
+
+    val prefValue: String
+        get() = name.lowercase()
+
+    fun isActive(systemInDarkMode: Boolean): Boolean =
+        when (this) {
+            OFF -> false
+            FOLLOW_SYSTEM -> systemInDarkMode
+            ON -> true
+        }
+
+    companion object {
+        fun fromPrefValue(value: String): ForceDarkMode =
+            entries.firstOrNull { it.prefValue == value.lowercase() }
+                ?: when (value.lowercase()) {
+                    "system",
+                    "follow_system",
+                    -> FOLLOW_SYSTEM
+
+                    "true",
+                    "enabled",
+                    "always",
+                    "dark",
+                    -> ON
+
+                    else -> OFF
+                }
+    }
+}

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/Prefs.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/Prefs.kt
@@ -18,6 +18,7 @@ object Prefs {
     val INJECTION_ENABLED = BoolPref("injection_enabled", true)
     val WEBVIEW_DEBUGGING = BoolPref("webview_debugging", false)
     val FORCE_DARK_WEBVIEW = BoolPref("force_dark_webview", false)
+    val FORCE_DARK_MODE = StringPref("force_dark_mode", ForceDarkMode.OFF.prefValue)
     val PRICE_CHARTS_ENABLED = BoolPref("price_charts_enabled", false)
 
     val LAST_REFRESH_FAILED = BoolPref("last_refresh_failed", false)
@@ -36,6 +37,7 @@ object Prefs {
             INJECTION_ENABLED,
             WEBVIEW_DEBUGGING,
             FORCE_DARK_WEBVIEW,
+            FORCE_DARK_MODE,
             PRICE_CHARTS_ENABLED,
             AUTO_UPDATE,
             DARK_THEME_CONFIG,
@@ -43,4 +45,13 @@ object Prefs {
         )
 
     fun parseSelectors(raw: String): List<String> = raw.lines().filter { it.isNotBlank() }
+
+    fun readForceDarkMode(prefs: android.content.SharedPreferences): ForceDarkMode =
+        if (prefs.contains(FORCE_DARK_MODE.key)) {
+            ForceDarkMode.fromPrefValue(FORCE_DARK_MODE.read(prefs))
+        } else if (FORCE_DARK_WEBVIEW.read(prefs)) {
+            ForceDarkMode.ON
+        } else {
+            ForceDarkMode.OFF
+        }
 }

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
@@ -19,7 +19,12 @@ data class PrefsSnapshot(
         get() = isForceDarkEnabled(currentApplication())
 
     fun isForceDarkEnabled(context: Context?): Boolean {
-        val nightMode = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
+        val nightMode =
+            context
+                ?.resources
+                ?.configuration
+                ?.uiMode
+                ?.and(Configuration.UI_MODE_NIGHT_MASK)
         return forceDarkMode.isActive(nightMode == Configuration.UI_MODE_NIGHT_YES)
     }
 }

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
@@ -9,9 +9,12 @@ data class PrefsSnapshot(
     val selectors: List<String>,
     val injectionEnabled: Boolean,
     val webviewDebugging: Boolean,
-    val forceDarkWebview: Boolean,
+    val forceDarkMode: ForceDarkMode,
     val priceChartsEnabled: Boolean,
-)
+) {
+    fun isForceDarkEnabled(systemInDarkMode: Boolean): Boolean =
+        forceDarkMode.isActive(systemInDarkMode)
+}
 
 object PrefsManager {
     @Volatile
@@ -35,8 +38,11 @@ object PrefsManager {
         private set
 
     @Volatile
-    var forceDarkWebview: Boolean = Prefs.FORCE_DARK_WEBVIEW.default
+    var forceDarkMode: ForceDarkMode = ForceDarkMode.OFF
         private set
+
+    val forceDarkWebview: Boolean
+        get() = forceDarkMode == ForceDarkMode.ON
 
     @Volatile
     var priceChartsEnabled: Boolean = Prefs.PRICE_CHARTS_ENABLED.default
@@ -61,7 +67,7 @@ object PrefsManager {
                 debugLogs = Prefs.DEBUG_LOGS.read(prefs)
                 injectionEnabled = Prefs.INJECTION_ENABLED.read(prefs)
                 webviewDebugging = Prefs.WEBVIEW_DEBUGGING.read(prefs)
-                forceDarkWebview = Prefs.FORCE_DARK_WEBVIEW.read(prefs)
+                forceDarkMode = Prefs.readForceDarkMode(prefs)
                 priceChartsEnabled = Prefs.PRICE_CHARTS_ENABLED.read(prefs)
             }
         }.onFailure { Logger.log("refreshCache() failed", it) }
@@ -72,7 +78,7 @@ object PrefsManager {
             selectors = selectors,
             injectionEnabled = injectionEnabled,
             webviewDebugging = webviewDebugging,
-            forceDarkWebview = forceDarkWebview,
+            forceDarkMode = forceDarkMode,
             priceChartsEnabled = priceChartsEnabled,
         )
 

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
@@ -1,7 +1,6 @@
 package eu.hxreborn.amznkiller.prefs
 
 import android.app.Application
-import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
 import eu.hxreborn.amznkiller.selectors.SelectorSanitizer
@@ -13,21 +12,9 @@ data class PrefsSnapshot(
     val injectionEnabled: Boolean,
     val webviewDebugging: Boolean,
     val forceDarkMode: ForceDarkMode,
+    val forceDarkWebview: Boolean,
     val priceChartsEnabled: Boolean,
-) {
-    val forceDarkWebview: Boolean
-        get() = isForceDarkEnabled(currentApplication())
-
-    fun isForceDarkEnabled(context: Context?): Boolean {
-        val nightMode =
-            context
-                ?.resources
-                ?.configuration
-                ?.uiMode
-                ?.and(Configuration.UI_MODE_NIGHT_MASK)
-        return forceDarkMode.isActive(nightMode == Configuration.UI_MODE_NIGHT_YES)
-    }
-}
+)
 
 object PrefsManager {
     @Volatile
@@ -92,8 +79,14 @@ object PrefsManager {
             injectionEnabled = injectionEnabled,
             webviewDebugging = webviewDebugging,
             forceDarkMode = forceDarkMode,
+            forceDarkWebview = forceDarkMode.isActive(systemInDarkMode()),
             priceChartsEnabled = priceChartsEnabled,
         )
+
+    private fun systemInDarkMode(): Boolean {
+        val uiMode = currentApplication()?.resources?.configuration?.uiMode ?: return false
+        return uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+    }
 
     fun setFallbackSelectors(fallback: List<String>) {
         selectors = fallback

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
@@ -1,6 +1,8 @@
 package eu.hxreborn.amznkiller.prefs
 
+import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.Configuration
 import eu.hxreborn.amznkiller.selectors.SelectorSanitizer
 import eu.hxreborn.amznkiller.util.Logger
 import io.github.libxposed.api.XposedInterface
@@ -12,8 +14,10 @@ data class PrefsSnapshot(
     val forceDarkMode: ForceDarkMode,
     val priceChartsEnabled: Boolean,
 ) {
-    fun isForceDarkEnabled(systemInDarkMode: Boolean): Boolean =
-        forceDarkMode.isActive(systemInDarkMode)
+    fun isForceDarkEnabled(context: Context?): Boolean {
+        val nightMode = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
+        return forceDarkMode.isActive(nightMode == Configuration.UI_MODE_NIGHT_YES)
+    }
 }
 
 object PrefsManager {
@@ -40,9 +44,6 @@ object PrefsManager {
     @Volatile
     var forceDarkMode: ForceDarkMode = ForceDarkMode.OFF
         private set
-
-    val forceDarkWebview: Boolean
-        get() = forceDarkMode == ForceDarkMode.ON
 
     @Volatile
     var priceChartsEnabled: Boolean = Prefs.PRICE_CHARTS_ENABLED.default

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsManager.kt
@@ -1,5 +1,6 @@
 package eu.hxreborn.amznkiller.prefs
 
+import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
@@ -14,6 +15,9 @@ data class PrefsSnapshot(
     val forceDarkMode: ForceDarkMode,
     val priceChartsEnabled: Boolean,
 ) {
+    val forceDarkWebview: Boolean
+        get() = isForceDarkEnabled(currentApplication())
+
     fun isForceDarkEnabled(context: Context?): Boolean {
         val nightMode = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
         return forceDarkMode.isActive(nightMode == Configuration.UI_MODE_NIGHT_YES)
@@ -44,6 +48,9 @@ object PrefsManager {
     @Volatile
     var forceDarkMode: ForceDarkMode = ForceDarkMode.OFF
         private set
+
+    val forceDarkWebview: Boolean
+        get() = snapshot().forceDarkWebview
 
     @Volatile
     var priceChartsEnabled: Boolean = Prefs.PRICE_CHARTS_ENABLED.default
@@ -92,3 +99,11 @@ object PrefsManager {
         return System.currentTimeMillis() - fetched > Prefs.STALE_THRESHOLD_MS
     }
 }
+
+private fun currentApplication(): Application? =
+    runCatching {
+        Class
+            .forName("android.app.ActivityThread")
+            .getMethod("currentApplication")
+            .invoke(null) as? Application
+    }.getOrNull()

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsRepository.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/prefs/PrefsRepository.kt
@@ -39,7 +39,7 @@ class PrefsRepositoryImpl(
                         debugLogs = Prefs.DEBUG_LOGS.read(localPrefs),
                         injectionEnabled = Prefs.INJECTION_ENABLED.read(localPrefs),
                         webviewDebugging = Prefs.WEBVIEW_DEBUGGING.read(localPrefs),
-                        forceDarkWebview = Prefs.FORCE_DARK_WEBVIEW.read(localPrefs),
+                        forceDarkMode = Prefs.readForceDarkMode(localPrefs),
                         priceChartsEnabled = Prefs.PRICE_CHARTS_ENABLED.read(localPrefs),
                         autoUpdate = Prefs.AUTO_UPDATE.read(localPrefs),
                         isStale =

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/ForceDarkModeDialog.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/ForceDarkModeDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.AlertDialog
@@ -61,7 +62,7 @@ internal fun ForceDarkModeDialog(
                             selected = option == currentMode,
                             onClick = null,
                         )
-                        Spacer(modifier = Modifier.padding(start = 16.dp))
+                        Spacer(modifier = Modifier.width(16.dp))
                         Text(
                             text = labels[index],
                             style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/ForceDarkModeDialog.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/ForceDarkModeDialog.kt
@@ -1,0 +1,91 @@
+package eu.hxreborn.amznkiller.ui.screen.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import eu.hxreborn.amznkiller.R
+import eu.hxreborn.amznkiller.prefs.ForceDarkMode
+import eu.hxreborn.amznkiller.ui.preview.PreviewLightDark
+import eu.hxreborn.amznkiller.ui.preview.PreviewWrapper
+import android.R as AndroidR
+
+@Composable
+internal fun ForceDarkModeDialog(
+    currentMode: ForceDarkMode,
+    onSelect: (ForceDarkMode) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val options = ForceDarkMode.entries
+    val labels =
+        listOf(
+            stringResource(R.string.settings_force_dark_off),
+            stringResource(R.string.settings_force_dark_follow_system),
+            stringResource(R.string.settings_force_dark_on),
+        )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_dark_mode)) },
+        text = {
+            Column(modifier = Modifier.selectableGroup()) {
+                options.forEachIndexed { index, option ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(56.dp)
+                                .selectable(
+                                    selected = option == currentMode,
+                                    onClick = { onSelect(option) },
+                                    role = Role.RadioButton,
+                                ).padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = option == currentMode,
+                            onClick = null,
+                        )
+                        Spacer(modifier = Modifier.padding(start = 16.dp))
+                        Text(
+                            text = labels[index],
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(AndroidR.string.cancel))
+            }
+        },
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun ForceDarkModeDialogPreview() {
+    PreviewWrapper {
+        ForceDarkModeDialog(
+            currentMode = ForceDarkMode.FOLLOW_SYSTEM,
+            onSelect = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/screen/settings/SettingsScreen.kt
@@ -40,19 +40,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.hxreborn.amznkiller.BuildConfig
 import eu.hxreborn.amznkiller.R
+import eu.hxreborn.amznkiller.prefs.ForceDarkMode
 import eu.hxreborn.amznkiller.prefs.PrefSpec
 import eu.hxreborn.amznkiller.prefs.Prefs
 import eu.hxreborn.amznkiller.ui.preview.PreviewLightDark
@@ -92,6 +90,7 @@ fun SettingsScreen(
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     var showThemeDialog by remember { mutableStateOf(false) }
     var showUrlDialog by remember { mutableStateOf(false) }
+    var showForceDarkModeDialog by remember { mutableStateOf(false) }
 
     if (showUrlDialog) {
         SelectorUrlDialog(
@@ -112,6 +111,17 @@ fun SettingsScreen(
                 showThemeDialog = false
             },
             onDismiss = { showThemeDialog = false },
+        )
+    }
+
+    if (showForceDarkModeDialog) {
+        ForceDarkModeDialog(
+            currentMode = prefs.forceDarkMode,
+            onSelect = { mode ->
+                viewModel.savePref(Prefs.FORCE_DARK_MODE, mode.prefValue)
+                showForceDarkModeDialog = false
+            },
+            onDismiss = { showForceDarkModeDialog = false },
         )
     }
 
@@ -158,23 +168,11 @@ fun SettingsScreen(
                 val appearanceItemCount = 2
                 val themeShape = shapeForPosition(appearanceItemCount, 0)
                 preference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = themeShape).clip(themeShape),
+                    modifier = preferenceModifier(surface, themeShape),
                     key = "theme",
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Palette,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_theme),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_theme_summary))
-                    },
+                    icon = { Icon(Icons.Outlined.Palette, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_theme) },
+                    summary = { Text(stringResource(R.string.settings_theme_summary)) },
                     onClick = { showThemeDialog = true },
                 )
 
@@ -182,64 +180,29 @@ fun SettingsScreen(
 
                 val dynamicColorShape = shapeForPosition(appearanceItemCount, 1)
                 switchPreference(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 8.dp)
-                            .background(color = surface, shape = dynamicColorShape)
-                            .clip(dynamicColorShape),
+                    modifier = preferenceModifier(surface, dynamicColorShape),
                     key = "dynamic_color",
                     value = prefs.useDynamicColor,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.FormatPaint,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_dynamic_color),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_dynamic_color_summary))
-                    },
+                    icon = { Icon(Icons.Outlined.FormatPaint, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_dynamic_color) },
+                    summary = { Text(stringResource(R.string.settings_dynamic_color_summary)) },
                     onValueChange = { viewModel.savePref(Prefs.USE_DYNAMIC_COLOR, it) },
                 )
 
                 preferenceCategory(
                     key = "category_ad_blocking",
-                    title = {
-                        Text(stringResource(R.string.settings_ad_blocking))
-                    },
+                    title = { Text(stringResource(R.string.settings_ad_blocking)) },
                 )
 
                 val adBlockItemCount = 3
                 val filteringShape = shapeForPosition(adBlockItemCount, 0)
                 switchPreference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = filteringShape).clip(filteringShape),
+                    modifier = preferenceModifier(surface, filteringShape),
                     key = "css_injection",
                     value = prefs.injectionEnabled,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Block,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_content_filtering),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.settings_content_filtering_summary,
-                                ),
-                        )
-                    },
+                    icon = { Icon(Icons.Outlined.Block, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_content_filtering) },
+                    summary = { Text(stringResource(R.string.settings_content_filtering_summary)) },
                     onValueChange = { viewModel.savePref(Prefs.INJECTION_ENABLED, it) },
                 )
 
@@ -247,134 +210,54 @@ fun SettingsScreen(
 
                 val syncShape = shapeForPosition(adBlockItemCount, 1)
                 switchPreference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = syncShape).clip(syncShape),
+                    modifier = preferenceModifier(surface, syncShape),
                     key = "auto_update",
                     value = prefs.autoUpdate,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.CloudSync,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_background_sync),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.settings_background_sync_summary,
-                                ),
-                        )
-                    },
+                    icon = { Icon(Icons.Outlined.CloudSync, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_background_sync) },
+                    summary = { Text(stringResource(R.string.settings_background_sync_summary)) },
                     onValueChange = { viewModel.savePref(Prefs.AUTO_UPDATE, it) },
                 )
 
-                item(key = "spacer_rule_1") { Spacer(Modifier.height(2.dp)) }
+                item { Spacer(Modifier.height(2.dp)) }
 
                 val filterSourcesShape = shapeForPosition(adBlockItemCount, 2)
                 preference(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 8.dp)
-                            .background(color = surface, shape = filterSourcesShape)
-                            .clip(filterSourcesShape),
+                    modifier = preferenceModifier(surface, filterSourcesShape),
                     key = "filter_sources",
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Link,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_filter_sources),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.settings_filter_sources_summary,
-                                ),
-                        )
-                    },
+                    icon = { Icon(Icons.Outlined.Link, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_filter_sources) },
+                    summary = { Text(stringResource(R.string.settings_filter_sources_summary)) },
                     onClick = { showUrlDialog = true },
                 )
 
                 preferenceCategory(
                     key = "category_shopping_display",
-                    title = {
-                        Text(stringResource(R.string.settings_shopping_display))
-                    },
+                    title = { Text(stringResource(R.string.settings_shopping_display)) },
                 )
 
                 val displayItemCount = 2
                 val chartsShape = shapeForPosition(displayItemCount, 0)
                 switchPreference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = chartsShape).clip(chartsShape),
+                    modifier = preferenceModifier(surface, chartsShape),
                     key = "price_charts",
                     value = prefs.priceChartsEnabled,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.TrendingUp,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_marketplace_insights),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.settings_marketplace_insights_summary,
-                                ),
-                        )
-                    },
+                    icon = { Icon(Icons.Outlined.TrendingUp, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_marketplace_insights) },
+                    summary = { Text(stringResource(R.string.settings_marketplace_insights_summary)) },
                     onValueChange = { viewModel.savePref(Prefs.PRICE_CHARTS_ENABLED, it) },
                 )
 
                 item { Spacer(Modifier.height(2.dp)) }
 
                 val darkModeShape = shapeForPosition(displayItemCount, 1)
-                switchPreference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = darkModeShape).clip(darkModeShape),
-                    key = "force_dark_webview",
-                    value = prefs.forceDarkWebview,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.DarkMode,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_dark_mode),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                buildAnnotatedString {
-                                    append(stringResource(R.string.settings_dark_mode_summary))
-                                    append("\n")
-                                    withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                        append("Note: ")
-                                    }
-                                    append("Requires Android 15 or higher to work properly")
-                                },
-                        )
-                    },
-                    onValueChange = { viewModel.savePref(Prefs.FORCE_DARK_WEBVIEW, it) },
+                preference(
+                    modifier = preferenceModifier(surface, darkModeShape),
+                    key = "force_dark_mode",
+                    icon = { Icon(Icons.Outlined.DarkMode, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_dark_mode) },
+                    summary = { Text(forceDarkModeSummary(prefs.forceDarkMode)) },
+                    onClick = { showForceDarkModeDialog = true },
                 )
 
                 preferenceCategory(
@@ -385,28 +268,12 @@ fun SettingsScreen(
                 val advancedItemCount = 3
                 val hideLauncherShape = shapeForPosition(advancedItemCount, 0)
                 switchPreference(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 8.dp)
-                            .background(color = surface, shape = hideLauncherShape)
-                            .clip(hideLauncherShape),
+                    modifier = preferenceModifier(surface, hideLauncherShape),
                     key = "hide_launcher_icon",
                     value = prefs.isLauncherIconHidden,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.PhonelinkErase,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_hide_launcher_icon),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_hide_launcher_icon_summary))
-                    },
+                    icon = { Icon(Icons.Outlined.PhonelinkErase, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_hide_launcher_icon) },
+                    summary = { Text(stringResource(R.string.settings_hide_launcher_icon_summary)) },
                     onValueChange = { viewModel.setLauncherIconHidden(it) },
                 )
 
@@ -414,60 +281,25 @@ fun SettingsScreen(
 
                 val webviewDebugShape = shapeForPosition(advancedItemCount, 1)
                 switchPreference(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 8.dp)
-                            .background(color = surface, shape = webviewDebugShape)
-                            .clip(webviewDebugShape),
+                    modifier = preferenceModifier(surface, webviewDebugShape),
                     key = "webview_debugging",
                     value = prefs.webviewDebugging,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.DeveloperMode,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_webview_debugging),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.settings_webview_debugging_summary,
-                                ),
-                        )
-                    },
-                    onValueChange = {
-                        viewModel.savePref(Prefs.WEBVIEW_DEBUGGING, it)
-                    },
+                    icon = { Icon(Icons.Rounded.DeveloperMode, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_webview_debugging) },
+                    summary = { Text(stringResource(R.string.settings_webview_debugging_summary)) },
+                    onValueChange = { viewModel.savePref(Prefs.WEBVIEW_DEBUGGING, it) },
                 )
 
                 item { Spacer(Modifier.height(2.dp)) }
 
                 val debugShape = shapeForPosition(advancedItemCount, 2)
                 switchPreference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = debugShape).clip(debugShape),
+                    modifier = preferenceModifier(surface, debugShape),
                     key = "debug_logs",
                     value = prefs.debugLogs,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.BugReport,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_debug_logs),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_debug_logs_summary))
-                    },
+                    icon = { Icon(Icons.Rounded.BugReport, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_debug_logs) },
+                    summary = { Text(stringResource(R.string.settings_debug_logs_summary)) },
                     onValueChange = { viewModel.savePref(Prefs.DEBUG_LOGS, it) },
                 )
 
@@ -479,52 +311,24 @@ fun SettingsScreen(
                 val aboutItemCount = 4
                 val versionShape = shapeForPosition(aboutItemCount, 0)
                 preference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = versionShape).clip(versionShape),
+                    modifier = preferenceModifier(surface, versionShape),
                     key = "app_version",
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Info,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_app_version),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(
-                            text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                        )
-                    },
+                    icon = { Icon(Icons.Rounded.Info, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_app_version) },
+                    summary = { Text("v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})") },
                 )
 
                 item { Spacer(Modifier.height(2.dp)) }
 
                 val gitRepoShape = shapeForPosition(aboutItemCount, 1)
                 preference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = gitRepoShape).clip(gitRepoShape),
+                    modifier = preferenceModifier(surface, gitRepoShape),
                     key = "git_repo",
-                    icon = {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_github_24),
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_git_repo),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_git_repo_summary))
-                    },
+                    icon = { Icon(painterResource(R.drawable.ic_github_24), contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_git_repo) },
+                    summary = { Text(stringResource(R.string.settings_git_repo_summary)) },
                     onClick = {
-                        context.startActivity(
-                            Intent(Intent.ACTION_VIEW, REPO_URL.toUri()),
-                        )
+                        context.startActivity(Intent(Intent.ACTION_VIEW, REPO_URL.toUri()))
                     },
                 )
 
@@ -532,23 +336,11 @@ fun SettingsScreen(
 
                 val licensesShape = shapeForPosition(aboutItemCount, 2)
                 preference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = licensesShape).clip(licensesShape),
+                    modifier = preferenceModifier(surface, licensesShape),
                     key = "licenses",
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Gavel,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_licenses),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_licenses_summary))
-                    },
+                    icon = { Icon(Icons.Outlined.Gavel, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_licenses) },
+                    summary = { Text(stringResource(R.string.settings_licenses_summary)) },
                     onClick = onNavigateToLicenses,
                 )
 
@@ -556,33 +348,43 @@ fun SettingsScreen(
 
                 val issueShape = shapeForPosition(aboutItemCount, 3)
                 preference(
-                    modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = issueShape).clip(issueShape),
+                    modifier = preferenceModifier(surface, issueShape),
                     key = "report_issue",
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Feedback,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(
-                            text = stringResource(R.string.settings_report_issue),
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    summary = {
-                        Text(text = stringResource(R.string.settings_report_issue_summary))
-                    },
+                    icon = { Icon(Icons.Outlined.Feedback, contentDescription = null) },
+                    title = { PreferenceTitle(R.string.settings_report_issue) },
+                    summary = { Text(stringResource(R.string.settings_report_issue_summary)) },
                     onClick = {
-                        context.startActivity(
-                            Intent(Intent.ACTION_VIEW, "$REPO_URL/issues/new/choose".toUri()),
-                        )
+                        context.startActivity(Intent(Intent.ACTION_VIEW, "$REPO_URL/issues/new/choose".toUri()))
                     },
                 )
             }
         }
     }
 }
+
+@Composable
+private fun PreferenceTitle(resId: Int) {
+    Text(
+        text = stringResource(resId),
+        style = MaterialTheme.typography.bodyLarge,
+    )
+}
+
+@Composable
+private fun forceDarkModeSummary(mode: ForceDarkMode): String {
+    val modeLabel =
+        when (mode) {
+            ForceDarkMode.OFF -> stringResource(R.string.settings_force_dark_off)
+            ForceDarkMode.FOLLOW_SYSTEM -> stringResource(R.string.settings_force_dark_follow_system)
+            ForceDarkMode.ON -> stringResource(R.string.settings_force_dark_on)
+        }
+    return stringResource(R.string.settings_dark_mode_summary_with_mode, modeLabel)
+}
+
+private fun preferenceModifier(
+    surface: androidx.compose.ui.graphics.Color,
+    shape: Shape,
+): Modifier = Modifier.padding(horizontal = 8.dp).background(color = surface, shape = shape).clip(shape)
 
 internal inline fun LazyListScope.switchPreference(
     key: String,
@@ -626,7 +428,7 @@ private class PreviewSettingsViewModel : AppViewModel() {
                 useDynamicColor = true,
                 debugLogs = false,
                 injectionEnabled = true,
-                forceDarkWebview = false,
+                forceDarkMode = ForceDarkMode.FOLLOW_SYSTEM,
             ),
         ).asStateFlow()
 

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/state/AppPrefsState.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/state/AppPrefsState.kt
@@ -1,5 +1,6 @@
 package eu.hxreborn.amznkiller.ui.state
 
+import eu.hxreborn.amznkiller.prefs.ForceDarkMode
 import eu.hxreborn.amznkiller.prefs.Prefs
 import eu.hxreborn.amznkiller.ui.theme.DarkThemeConfig
 
@@ -10,7 +11,7 @@ data class AppPrefsState(
     val debugLogs: Boolean = Prefs.DEBUG_LOGS.default,
     val injectionEnabled: Boolean = Prefs.INJECTION_ENABLED.default,
     val webviewDebugging: Boolean = Prefs.WEBVIEW_DEBUGGING.default,
-    val forceDarkWebview: Boolean = Prefs.FORCE_DARK_WEBVIEW.default,
+    val forceDarkMode: ForceDarkMode = ForceDarkMode.OFF,
     val priceChartsEnabled: Boolean = Prefs.PRICE_CHARTS_ENABLED.default,
     val autoUpdate: Boolean = Prefs.AUTO_UPDATE.default,
     val isStale: Boolean = true,

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/state/SettingsUiState.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/state/SettingsUiState.kt
@@ -1,6 +1,7 @@
 package eu.hxreborn.amznkiller.ui.state
 
 import androidx.compose.runtime.Immutable
+import eu.hxreborn.amznkiller.prefs.ForceDarkMode
 import eu.hxreborn.amznkiller.prefs.Prefs
 import eu.hxreborn.amznkiller.ui.theme.DarkThemeConfig
 
@@ -14,7 +15,7 @@ sealed interface SettingsUiState {
         val injectionEnabled: Boolean = Prefs.INJECTION_ENABLED.default,
         val debugLogs: Boolean = Prefs.DEBUG_LOGS.default,
         val webviewDebugging: Boolean = Prefs.WEBVIEW_DEBUGGING.default,
-        val forceDarkWebview: Boolean = Prefs.FORCE_DARK_WEBVIEW.default,
+        val forceDarkMode: ForceDarkMode = ForceDarkMode.OFF,
         val priceChartsEnabled: Boolean = Prefs.PRICE_CHARTS_ENABLED.default,
         val darkThemeConfig: DarkThemeConfig = DarkThemeConfig.FOLLOW_SYSTEM,
         val useDynamicColor: Boolean = Prefs.USE_DYNAMIC_COLOR.default,

--- a/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/viewmodel/AppViewModelImpl.kt
+++ b/app/src/main/kotlin/eu/hxreborn/amznkiller/ui/viewmodel/AppViewModelImpl.kt
@@ -73,7 +73,7 @@ class AppViewModelImpl(
                 injectionEnabled = prefs.injectionEnabled,
                 debugLogs = prefs.debugLogs,
                 webviewDebugging = prefs.webviewDebugging,
-                forceDarkWebview = prefs.forceDarkWebview,
+                forceDarkMode = prefs.forceDarkMode,
                 priceChartsEnabled = prefs.priceChartsEnabled,
                 darkThemeConfig = prefs.darkThemeConfig,
                 useDynamicColor = prefs.useDynamicColor,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,10 @@
     <string name="settings_marketplace_insights_summary">Show Keepa and CamelCamelCamel charts on product pages</string>
     <string name="settings_dark_mode">Dark mode (experimental)</string>
     <string name="settings_dark_mode_summary">Apply dark mode to Amazon pages. Requires force stopping Amazon to take effect</string>
+    <string name="settings_dark_mode_summary_with_mode">%1$s. Requires force stopping Amazon to take effect. Requires Android 15 or higher to work properly</string>
+    <string name="settings_force_dark_off">Off</string>
+    <string name="settings_force_dark_follow_system">Follow system dark mode</string>
+    <string name="settings_force_dark_on">On</string>
     <string name="settings_webview_debugging">WebView debugging</string>
     <string name="settings_webview_debugging_summary">Attach DevTools to Amazon WebViews. Requires force stopping Amazon to take effect</string>
     <string name="settings_debug_logs_summary">Write verbose hook and injection logs. Disable when not debugging</string>


### PR DESCRIPTION
This pull request introduces a new, more flexible "Force Dark Mode" preference that replaces the old boolean-based dark mode setting. The new implementation allows users to explicitly choose between Off, Follow System, or On, improving user control and compatibility with different Android versions. The changes span preference storage, state management, UI, and string resources.

**Force Dark Mode Preference Refactor:**

- Added a new `ForceDarkMode` enum to represent dark mode options (Off, Follow System, On), with logic for parsing and determining active state.
- Updated preference storage (`Prefs`, `PrefsManager`, `PrefsRepositoryImpl`) to use the new `ForceDarkMode` enum instead of the old boolean `forceDarkWebview`, including migration logic for backward compatibility. [[1]](diffhunk://#diff-a386a2d477bed9d25d995bc5e8ecfd12f6cdb63f56c6fca058ca1ffc73838286R21) [[2]](diffhunk://#diff-a386a2d477bed9d25d995bc5e8ecfd12f6cdb63f56c6fca058ca1ffc73838286R40-R56) [[3]](diffhunk://#diff-ce09e85cd13278b857d4afb6c7a026078cbc602d91c5c850f7d866dce4963c2fL12-R30) [[4]](diffhunk://#diff-ce09e85cd13278b857d4afb6c7a026078cbc602d91c5c850f7d866dce4963c2fL38-R59) [[5]](diffhunk://#diff-ce09e85cd13278b857d4afb6c7a026078cbc602d91c5c850f7d866dce4963c2fL64-R83) [[6]](diffhunk://#diff-ce09e85cd13278b857d4afb6c7a026078cbc602d91c5c850f7d866dce4963c2fL75-R94) [[7]](diffhunk://#diff-309c374eb17616f9fba00c125f84d88e9726a01c9b69c27e7d626fef531de569L42-R42)
- Updated all relevant state classes (`AppPrefsState`, `SettingsUiState`) and view models to use the new `forceDarkMode` property. [[1]](diffhunk://#diff-17910c072182c35a3f29ebb319840c65b368fc738a31628728f29cf2949b2420R3) [[2]](diffhunk://#diff-17910c072182c35a3f29ebb319840c65b368fc738a31628728f29cf2949b2420L13-R14) [[3]](diffhunk://#diff-90852b08441950976dce451d22b0bbc317b6e3ef43186cbf6dcccfdb3da3982fR4) [[4]](diffhunk://#diff-90852b08441950976dce451d22b0bbc317b6e3ef43186cbf6dcccfdb3da3982fL17-R18) [[5]](diffhunk://#diff-5f9b0bb40eaa6651aa1056997851e5ac044ebb2b454c3d0d23aa7dd294dde62eL76-R76)

**User Interface Enhancements:**

- Added a new `ForceDarkModeDialog` composable for selecting the dark mode preference, with corresponding preview and string resources for all options. [[1]](diffhunk://#diff-fae0dd1ae1ad2892e94bf15094ecab6fec7c9f52c3d30c4d4b9cbfa4cba04c88R1-R91) [[2]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R58-R61)

**Continuous Integration Improvements:**

- Updated the Android CI workflow to upload debug and release APKs as artifacts for easier access after builds.<!-- PR title must follow conventional commits: type(scope): description -->
